### PR TITLE
Rename the name 'slack-connector' to 'slack'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CREATE TEMPORARY TABLE slack_example (
     `channel_id` STRING,
     `message` STRING 
 ) WITH (
-    'connector' = 'slack-connector',
+    'connector' = 'slack',
     'token' = BOT_USER_OAUTH_ACCESS_TOKEN
 );
 ```
@@ -46,7 +46,7 @@ CREATE TEMPORARY TABLE slack_example_with_reply (
     `thread` STRING,
     `message` STRING 
 ) WITH (
-    'connector' = 'slack-connector',
+    'connector' = 'slack',
     'token' = BOT_USER_OAUTH_ACCESS_TOKEN
 );
 ```
@@ -67,7 +67,7 @@ CREATE TEMPORARY TABLE slack_example_formatted (
     `thread` STRING,
     `formatted` STRING 
 ) WITH (
-    'connector' = 'slack-connector',
+    'connector' = 'slack',
     'token' = BOT_USER_OAUTH_ACCESS_TOKEN
 );
 ```

--- a/src/main/java/io/aiven/flink/connectors/slack/sink/SlackTableSinkFactory.java
+++ b/src/main/java/io/aiven/flink/connectors/slack/sink/SlackTableSinkFactory.java
@@ -23,7 +23,7 @@ public class SlackTableSinkFactory implements DynamicTableSinkFactory {
 
   @Override
   public String factoryIdentifier() {
-    return "slack-connector";
+    return "slack";
   }
 
   @Override

--- a/src/main/java/io/aiven/flink/connectors/slack/source/FlinkSlackConnectorTableSourceFactory.java
+++ b/src/main/java/io/aiven/flink/connectors/slack/source/FlinkSlackConnectorTableSourceFactory.java
@@ -37,7 +37,7 @@ public class FlinkSlackConnectorTableSourceFactory implements DynamicTableSource
 
   @Override
   public String factoryIdentifier() {
-    return "slack-connector";
+    return "slack";
   }
 
   @Override

--- a/src/test/java/io/aiven/flink/connectors/slack/FlinkSlackConnectorIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/slack/FlinkSlackConnectorIntegrationTest.java
@@ -32,7 +32,7 @@ public class FlinkSlackConnectorIntegrationTest {
                 + "  `channel_id` STRING,\n"
                 + "  `message` STRING \n"
                 + ") WITH (\n"
-                + "  'connector' = 'slack-connector',"
+                + "  'connector' = 'slack',"
                 + "  'token' = '"
                 + BOT_TOKEN
                 + "'"
@@ -62,7 +62,7 @@ public class FlinkSlackConnectorIntegrationTest {
             + "  `client_msg_id` STRING,\n"
             + "  `text` STRING \n"
             + ") WITH (\n"
-            + "  'connector' = 'slack-connector',"
+            + "  'connector' = 'slack',"
             + "  'apptoken' = '"
             + APP_TOKEN
             + "'"

--- a/src/test/java/io/aiven/flink/connectors/slack/FlinkSlackIntegrationTest.java
+++ b/src/test/java/io/aiven/flink/connectors/slack/FlinkSlackIntegrationTest.java
@@ -63,7 +63,7 @@ public class FlinkSlackIntegrationTest {
                 + "  `title` STRING,\n"
                 + "  `description` STRING \n"
                 + ") WITH (\n"
-                + "  'connector' = 'slack-connector',"
+                + "  'connector' = 'slack',"
                 + "  'token' = '"
                 + VALID_APP_TOKEN
                 + "'"


### PR DESCRIPTION
Small proposal that would propably be easier to apply early on. 

When using a connector, the names are like following: 
kafka, upsert-kafka, jdbc, elasticsearch-7 and so on (no `-connector` postfix). 

Having the -connector postfix here feels redundant.

Proposing to just call it 'slack', so when writing the connector name in the CREATE TABLE statement, it would be written as:
`'connector' = 'slack'` instead of `'connector' = 'slack-connector'`